### PR TITLE
Add a callback and print out the error from executor

### DIFF
--- a/DGVisualStudioCodeIntegration.pas
+++ b/DGVisualStudioCodeIntegration.pas
@@ -141,7 +141,11 @@ begin
   try
      executor.WorkDir := ExtractFilePath(filename);
      executor.CmdLine := Cmdline;
-     executor.Execute;
+     executor.Execute(
+       procedure(Txt: string)
+       begin
+        ShowMessage(Format('Execution error: %s', [Txt]));
+       end, nil);
   finally
      executor.Free;
   end;


### PR DESCRIPTION
Fixes issue described in #5 