### PR TITLE
Add Devin Desktop as built-in editor

### DIFF
--- a/FrmSettingsFrame.dfm
+++ b/FrmSettingsFrame.dfm
@@ -2,7 +2,7 @@ object FrmSettingsFrame: TFrmSettingsFrame
   Left = 0
   Top = 0
   Width = 611
-  Height = 511
+  Height = 569
   TabOrder = 0
   object lblBuiltInHint: TLabel
     Left = 16
@@ -15,7 +15,7 @@ object FrmSettingsFrame: TFrmSettingsFrame
   end
   object lblCustomEditorsHint: TLabel
     Left = 16
-    Top = 319
+    Top = 377
     Width = 332
     Height = 30
     Caption =
@@ -53,6 +53,13 @@ object FrmSettingsFrame: TFrmSettingsFrame
   object Label5: TLabel
     Left = 52
     Top = 282
+    Width = 38
+    Height = 15
+    Caption = 'Hotkey'
+  end
+  object Label6: TLabel
+    Left = 52
+    Top = 340
     Width = 38
     Height = 15
     Caption = 'Hotkey'
@@ -191,119 +198,163 @@ object FrmSettingsFrame: TFrmSettingsFrame
     TabOrder = 12
     OnClick = BuiltInAdvancedSettingsClick
   end
-  object chkTraeEnabled: TCheckBox
+  object chkDevinEnabled: TCheckBox
     Left = 16
     Top = 196
     Width = 121
     Height = 17
-    Caption = 'TRAE'
-    TabOrder = 12
+    Caption = 'Devin Desktop'
+    TabOrder = 13
   end
-  object lnkTraeHome: TLinkLabel
+  object lnkDevinHome: TLinkLabel
     Left = 152
     Top = 196
-    Width = 71
+    Width = 100
     Height = 19
-    Caption = '<a href="https://www.trae.ai/">www.trae.ai/</a>'
-    TabOrder = 13
+    Caption = '<a href="https://devin.ai/desktop">devin.ai/desktop</a>'
+    TabOrder = 14
     OnLinkClick = HomePageLinkClick
   end
-  object hkTraeShortcut: THotKey
+  object hkDevinShortcut: THotKey
     Left = 94
     Top = 221
     Width = 105
     Height = 23
     HotKey = 0
     Modifiers = []
-    TabOrder = 14
+    TabOrder = 15
   end
-  object btnTraeClearShortcut: TButton
+  object btnDevinClearShortcut: TButton
     Left = 205
     Top = 219
     Width = 44
     Height = 25
     Caption = 'Clear'
-    TabOrder = 15
+    TabOrder = 16
     OnClick = BuiltInClearShortcutClick
   end
-  object btnTraeAdvanced: TButton
+  object btnDevinAdvanced: TButton
     Left = 255
     Top = 219
     Width = 130
     Height = 25
     Caption = 'Advanced Settings...'
-    TabOrder = 16
+    TabOrder = 17
     OnClick = BuiltInAdvancedSettingsClick
   end
-  object chkVSCodiumEnabled: TCheckBox
+  object chkTraeEnabled: TCheckBox
     Left = 16
     Top = 254
     Width = 121
     Height = 17
-    Caption = 'VSCodium'
-    TabOrder = 16
+    Caption = 'TRAE'
+    TabOrder = 18
   end
-  object lnkVSCodiumHome: TLinkLabel
+  object lnkTraeHome: TLinkLabel
     Left = 152
     Top = 254
-    Width = 88
+    Width = 71
     Height = 19
-    Caption = '<a href="https://vscodium.com/">vscodium.com/</a>'
-    TabOrder = 17
+    Caption = '<a href="https://www.trae.ai/">www.trae.ai/</a>'
+    TabOrder = 19
     OnLinkClick = HomePageLinkClick
   end
-  object hkVSCodiumShortcut: THotKey
+  object hkTraeShortcut: THotKey
     Left = 94
     Top = 279
     Width = 105
     Height = 23
     HotKey = 0
     Modifiers = []
-    TabOrder = 18
+    TabOrder = 20
   end
-  object btnVSCodiumClearShortcut: TButton
+  object btnTraeClearShortcut: TButton
     Left = 205
     Top = 277
     Width = 44
     Height = 25
     Caption = 'Clear'
-    TabOrder = 19
+    TabOrder = 21
     OnClick = BuiltInClearShortcutClick
   end
-  object btnVSCodiumAdvanced: TButton
+  object btnTraeAdvanced: TButton
     Left = 255
     Top = 277
     Width = 130
     Height = 25
     Caption = 'Advanced Settings...'
-    TabOrder = 20
+    TabOrder = 22
+    OnClick = BuiltInAdvancedSettingsClick
+  end
+  object chkVSCodiumEnabled: TCheckBox
+    Left = 16
+    Top = 312
+    Width = 121
+    Height = 17
+    Caption = 'VSCodium'
+    TabOrder = 23
+  end
+  object lnkVSCodiumHome: TLinkLabel
+    Left = 152
+    Top = 312
+    Width = 88
+    Height = 19
+    Caption = '<a href="https://vscodium.com/">vscodium.com/</a>'
+    TabOrder = 24
+    OnLinkClick = HomePageLinkClick
+  end
+  object hkVSCodiumShortcut: THotKey
+    Left = 94
+    Top = 337
+    Width = 105
+    Height = 23
+    HotKey = 0
+    Modifiers = []
+    TabOrder = 25
+  end
+  object btnVSCodiumClearShortcut: TButton
+    Left = 205
+    Top = 335
+    Width = 44
+    Height = 25
+    Caption = 'Clear'
+    TabOrder = 26
+    OnClick = BuiltInClearShortcutClick
+  end
+  object btnVSCodiumAdvanced: TButton
+    Left = 255
+    Top = 335
+    Width = 130
+    Height = 25
+    Caption = 'Advanced Settings...'
+    TabOrder = 27
     OnClick = BuiltInAdvancedSettingsClick
   end
   object sbCustomEditors: TScrollBox
     Left = 16
-    Top = 352
+    Top = 410
     Width = 580
     Height = 116
-    TabOrder = 21
+    TabOrder = 28
   end
   object btnAddCustomEditor: TButton
     Left = 426
-    Top = 474
+    Top = 532
     Width = 170
     Height = 25
     Caption = 'Add Custom Editor...'
-    TabOrder = 22
+    TabOrder = 29
     OnClick = btnAddCustomEditorClick
   end
   object lnkProjectHome: TLinkLabel
     Left = 16
-    Top = 478
+    Top = 536
     Width = 162
     Height = 19
     Caption =
       '<a href="https://github.com/csm101/EditInVsCodeDelphiPlugin">Pro' +
       'ject home page on GitHub</a>'
-    TabOrder = 23
+    TabOrder = 30
     OnLinkClick = HomePageLinkClick
   end
 end

--- a/FrmSettingsFrame.pas
+++ b/FrmSettingsFrame.pas
@@ -48,6 +48,11 @@ type
     hkWindsurfShortcut: THotKey;
     btnWindsurfClearShortcut: TButton;
     btnWindsurfAdvanced: TButton;
+    chkDevinEnabled: TCheckBox;
+    lnkDevinHome: TLinkLabel;
+    hkDevinShortcut: THotKey;
+    btnDevinClearShortcut: TButton;
+    btnDevinAdvanced: TButton;
     chkTraeEnabled: TCheckBox;
     lnkTraeHome: TLinkLabel;
     hkTraeShortcut: THotKey;
@@ -68,6 +73,7 @@ type
     Label3: TLabel;
     Label4: TLabel;
     Label5: TLabel;
+    Label6: TLabel;
     procedure BuiltInAdvancedSettingsClick(Sender: TObject);
     procedure btnAddCustomEditorClick(Sender: TObject);
     procedure BuiltInClearShortcutClick(Sender: TObject);
@@ -161,6 +167,8 @@ begin
     EditorDraft := FindBuiltInEditorDraft('cursor')
   else if Sender = btnWindsurfAdvanced then
     EditorDraft := FindBuiltInEditorDraft('windsurf')
+  else if Sender = btnDevinAdvanced then
+    EditorDraft := FindBuiltInEditorDraft('devin')
   else if Sender = btnTraeAdvanced then
     EditorDraft := FindBuiltInEditorDraft('trae')
   else if Sender = btnVSCodiumAdvanced then
@@ -197,6 +205,8 @@ begin
     hkCursorShortcut.HotKey := 0
   else if Sender = btnWindsurfClearShortcut then
     hkWindsurfShortcut.HotKey := 0
+  else if Sender = btnDevinClearShortcut then
+    hkDevinShortcut.HotKey := 0
   else if Sender = btnTraeClearShortcut then
     hkTraeShortcut.HotKey := 0
   else if Sender = btnVSCodiumClearShortcut then
@@ -329,6 +339,7 @@ begin
   LoadBuiltInEditorControl('vscode', chkVSCodeEnabled, hkVSCodeShortcut);
   LoadBuiltInEditorControl('cursor', chkCursorEnabled, hkCursorShortcut);
   LoadBuiltInEditorControl('windsurf', chkWindsurfEnabled, hkWindsurfShortcut);
+  LoadBuiltInEditorControl('devin', chkDevinEnabled, hkDevinShortcut);
   LoadBuiltInEditorControl('trae', chkTraeEnabled, hkTraeShortcut);
   LoadBuiltInEditorControl('vscodium', chkVSCodiumEnabled, hkVSCodiumShortcut);
 end;
@@ -499,6 +510,7 @@ begin
   SaveBuiltInEditorControl('vscode', chkVSCodeEnabled, hkVSCodeShortcut);
   SaveBuiltInEditorControl('cursor', chkCursorEnabled, hkCursorShortcut);
   SaveBuiltInEditorControl('windsurf', chkWindsurfEnabled, hkWindsurfShortcut);
+  SaveBuiltInEditorControl('devin', chkDevinEnabled, hkDevinShortcut);
   SaveBuiltInEditorControl('trae', chkTraeEnabled, hkTraeShortcut);
   SaveBuiltInEditorControl('vscodium', chkVSCodiumEnabled, hkVSCodiumShortcut);
 end;

--- a/PluginSettings.pas
+++ b/PluginSettings.pas
@@ -318,7 +318,7 @@ end;
 
 class procedure TPluginSettings.AddDefaultBuiltInEditors;
 begin
-  for var EditorId in ['vscode', 'cursor', 'windsurf', 'trae', 'vscodium'] do
+  for var EditorId in ['vscode', 'cursor', 'windsurf', 'devin', 'trae', 'vscodium'] do
     FBuiltInEditors.Add(CreateDefaultBuiltInEditorCopy(EditorId));
 end;
 
@@ -372,6 +372,13 @@ begin
     Result := CreateBuiltInEditor(
       'windsurf', 'Windsurf', 'https://windsurf.com/editor',
       'windsurf', 'Windsurf', False, 0);
+    Exit;
+  end;
+
+  if SameText(EditorId, 'devin') then begin
+    Result := CreateBuiltInEditor(
+      'devin', 'Devin Desktop', 'https://devin.ai/desktop',
+      'devin', 'Devin', False, 0);
     Exit;
   end;
 


### PR DESCRIPTION
## Summary

Adds **Devin Desktop** (https://devin.ai/desktop) as a new built-in editor option,
positioned between Windsurf and TRAE in the editor list.

Devin Desktop is the successor to Windsurf, built on the same VS Code fork
architecture. The existing Windsurf integration remains unchanged.

## Details

- **Editor ID:** `devin`
- **Display name:** Devin Desktop
- **CLI command:** `devin`
- **Window class:** `Chrome_WidgetWin_1` (standard VS Code fork)
- **Window title suffix:** Devin
- **Homepage:** https://devin.ai/desktop

## Changes

- [PluginSettings.pas](cci:7://file:///c:/Arbejdsfiler/GitHub/EditInVsCodeDelphiPlugin/PluginSettings.pas:0:0-0:0) — Added `devin` to `AddDefaultBuiltInEditors` and new
  `CreateDefaultBuiltInEditorCopy` block
- [FrmSettingsFrame.pas](cci:7://file:///c:/Arbejdsfiler/GitHub/EditInVsCodeDelphiPlugin/FrmSettingsFrame.pas:0:0-0:0) — Added field declarations and wired up Load/Save/Click handlers
- [FrmSettingsFrame.dfm](cci:7://file:///c:/Arbejdsfiler/GitHub/EditInVsCodeDelphiPlugin/FrmSettingsFrame.dfm:0:0-0:0) — Added UI controls and adjusted layout positions

## Testing

Verified in Delphi IDE — the Devin Desktop option appears correctly in the
settings frame and works when the path to `devin.exe` is configured via
Advanced Settings.